### PR TITLE
Bypass registration requirement if Retropilot servers are down

### DIFF
--- a/selfdrive/athena/registration.py
+++ b/selfdrive/athena/registration.py
@@ -10,7 +10,7 @@ from common.params import Params
 from common.spinner import Spinner
 from common.basedir import PERSIST
 from selfdrive.controls.lib.alertmanager import set_offroad_alert
-from selfdrive.hardware import HARDWARE, PC
+from selfdrive.hardware import HARDWARE
 from selfdrive.swaglog import cloudlog
 
 
@@ -64,6 +64,7 @@ def register(show_spinner=False) -> str:
 
     backoff = 0
     start_time = time.monotonic()
+    try_count = 0
     while True:
       try:
         register_token = jwt.encode({'register': True, 'exp': datetime.utcnow() + timedelta(hours=1)}, private_key, algorithm='RS256')
@@ -71,7 +72,7 @@ def register(show_spinner=False) -> str:
         resp = api_get("v2/pilotauth/", method='POST', timeout=15,
                        imei=imei1, imei2=imei2, serial=serial, public_key=public_key, register_token=register_token)
 
-        if resp.status_code in (402, 403):
+        if resp.status_code in (402, 403, 404):
           cloudlog.info(f"Unable to register device, got {resp.status_code}")
           dongle_id = UNREGISTERED_DONGLE_ID
         else:
@@ -79,6 +80,10 @@ def register(show_spinner=False) -> str:
           dongle_id = dongleauth["dongle_id"]
         break
       except Exception:
+        try_count += 1
+        if try_count >= 2:
+          dongle_id = UNREGISTERED_DONGLE_ID
+          break
         cloudlog.exception("failed to authenticate")
         backoff = min(backoff + 1, 15)
         time.sleep(backoff)
@@ -91,7 +96,7 @@ def register(show_spinner=False) -> str:
 
   if dongle_id:
     params.put("DongleId", dongle_id)
-    set_offroad_alert("Offroad_UnofficialHardware", (dongle_id == UNREGISTERED_DONGLE_ID) and not PC)
+    set_offroad_alert("Offroad_UnofficialHardware", dongle_id == UNREGISTERED_DONGLE_ID)
   return dongle_id
 
 


### PR DESCRIPTION
If a 404 error is received from the registration server, it will bypass the registration screen and show as unregistered. This fixes not being able to install a new copy of Circuit-Pro and getting stuck endlessly on the registration screen.